### PR TITLE
Bug fix: Modify addUserToDB to use auth uid as the document id for users

### DIFF
--- a/server/functions/src/https/user.ts
+++ b/server/functions/src/https/user.ts
@@ -69,3 +69,35 @@ export const deleteAccount = functions.https.onCall(async (data, context) => {
   let uid = data.uid;
   await admin.firestore().collection("users").doc(uid).delete();
 });
+
+export const modifyFollowing = functions.https.onRequest(async (request, response) => {
+  let following = request.body.following;
+  let uid = request.body.uid;
+
+  await admin.firestore().collection("users").doc(uid).update({
+    following: following
+  })
+
+})
+
+export const getUserInfo = functions.https.onCall(async (data, contxt) => {
+  let username = data.username;
+  const query = await admin.firestore().collection("users").where("username", "==", username)
+  .get()
+  .then((querySnapShot) => {
+    let result;
+    let dId;
+    querySnapShot.forEach(function (doc) {
+      result = doc.data();
+      dId = doc.id;
+    })
+    return {dId: result}
+  })
+  .catch((err) => {
+    throw new functions.https.HttpsError(
+      "unknown",
+      `Something went wrong when accessing the database. Reason ${err}`
+    );
+  });
+  return query;
+})


### PR DESCRIPTION
Notes:
- uid is now fetched from the context so no need to pass it in as a param
- uid is no longer a field in the document
- Return result is now an object that contains a message